### PR TITLE
Remove finalizer migration logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove the code piece that cleans old finalizers for migration.
+
 ## [0.5.0] - 2022-08-10
 
 ### Changed

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -129,16 +129,6 @@ func (r *ClusterReconciler) reconcileNormal(ctx context.Context, clusterScope *s
 		}
 	}
 
-	// TODO start: delete after all CAPO based clusters got migrated to new finalizer
-	// remove the old finalizer from infrastructure clusters
-	if controllerutil.ContainsFinalizer(infraCluster, key.DNSFinalizerNameOld) {
-		controllerutil.RemoveFinalizer(infraCluster, key.DNSFinalizerNameOld)
-		if err := r.Update(ctx, infraCluster); err != nil {
-			return reconcile.Result{}, microerror.Mask(err)
-		}
-	}
-	// TODO end
-
 	route53Service := route53.NewService(clusterScope)
 	err := route53Service.ReconcileRoute53(ctx)
 	if route53.IsIngressNotReady(err) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1247

We have migrated all CAPO clusters (prod + tests) so we can remove this migration logic.

### Checklist

- [x] Update changelog in CHANGELOG.md.
