### PR TITLE
only reconcile provisioned clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Normal reconciliation is only done if a cluster is in `Provisioned` state.
 - Remove the code piece that cleans old finalizers for migration.
 
 ## [0.5.0] - 2022-08-10


### PR DESCRIPTION
We rely on many fields during the DNS record generation which are only existing in the spec if the cluster is already provisioned.

In the current implementation we are getting following error if a cluster is in Provisioning phase:

```
1.6643473740557249e+09  ERROR   controller.cluster      error creating route53  {"reconciler group": "cluster.x-k8s.io", "reconciler kind": "Cluster", "name": "mario15", "namespace": "org-single-gs2", "error": "MissingEndpoint: 'Endpoint' configuration is required for this service"}

```


<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
