### PR TITLE
Cache route53 API responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dns-operator-route53*
+/dns-operator-route53*
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dns-operator-route53*
+.vscode/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove CAPO go dependency.
 - Normal reconciliation is only done if a cluster is in `Provisioned` state.
+- Cache route53 API responses.
+- Expose metrics about the internal cache.
 - Remove the code piece that cleans old finalizers for migration.
 
 ## [0.5.0] - 2022-08-10

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/giantswarm/k8sclient/v6 v6.1.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v1.0.0
-	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	golang.org/x/text v0.3.7

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/giantswarm/dns-operator-route53
 go 1.18
 
 require (
+	github.com/allegro/bigcache/v3 v3.0.2
 	github.com/aws/aws-sdk-go v1.44.57
 	github.com/giantswarm/k8sclient/v6 v6.1.0
 	github.com/giantswarm/microerror v0.4.0
 	github.com/giantswarm/micrologger v1.0.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/allegro/bigcache/v3 v3.0.2 h1:AKZCw+5eAaVyNTBmI2fgyPVJhHkdWder3O9IrprcQfI=
+github.com/allegro/bigcache/v3 v3.0.2/go.mod h1:aPyh7jEvrog9zAwx5N7+JUQX5dZTSGpxF1LAR4dr35I=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210826220005-b48c857c3a0e/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -538,6 +540,8 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,6 @@ github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
-github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
-github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/helm/dns-operator-route53/templates/deployment.yaml
+++ b/helm/dns-operator-route53/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         - --enable-leader-election
         - --base-domain={{ .Values.baseDomain }}
         - --management-cluster={{ .Values.managementCluster }}
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
         resources:
           requests:
             memory: 100Mi

--- a/helm/dns-operator-route53/templates/deployment.yaml
+++ b/helm/dns-operator-route53/templates/deployment.yaml
@@ -38,11 +38,9 @@ spec:
         - --management-cluster={{ .Values.managementCluster }}
         resources:
           requests:
-            cpu: 100m
-            memory: 50Mi
+            memory: 100Mi
           limits:
-            cpu: 100m
-            memory: 80Mi
+            memory: 100Mi
         volumeMounts:
         - mountPath: /home/.aws
           name: credentials

--- a/helm/dns-operator-route53/templates/servicemonitor.yaml
+++ b/helm/dns-operator-route53/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: "monitoring.coreos.com/v1"
+kind: ServiceMonitor
+metadata:
+  labels: {{- include "labels.common" . | nindent 4}}
+  name: {{include "name" .}}
+  namespace: {{.Release.Namespace}}
+spec:
+  selector:
+    matchLabels:
+      {{- include "labels.selector" . | nindent 6}}
+  namespaceSelector:
+    matchNames:
+      - {{.Release.Namespace}}
+  endpoints:
+    - port: metrics
+      interval: 30s
+      scrapeTimeout: 25s

--- a/main.go
+++ b/main.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/giantswarm/dns-operator-route53/controllers"
 
-	"github.com/allegro/bigcache/v3"
 	dnscache "github.com/giantswarm/dns-operator-route53/pkg/cloud/cache"
 	// +kubebuilder:scaffold:imports
 )
@@ -67,7 +66,12 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	// Initialize the cache with a custom configuration
-	dnscache.DNSOperatorCache, _ = bigcache.NewBigCache(dnscache.Config)
+	var err error
+	dnscache.DNSOperatorCache, err = dnscache.NewDNSOperatorCache()
+	if err != nil {
+		setupLog.Error(err, "unable to create the cache")
+		os.Exit(1)
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/giantswarm/dns-operator-route53/controllers"
+
+	"github.com/allegro/bigcache/v3"
+	dnscache "github.com/giantswarm/dns-operator-route53/pkg/cloud/cache"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -63,6 +66,9 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
+	// Initialize the cache with a custom configuration
+	dnscache.DNSOperatorCache, _ = bigcache.NewBigCache(dnscache.Config)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
@@ -76,8 +82,7 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterReconciler{
-		Client: mgr.GetClient(),
-
+		Client:            mgr.GetClient(),
 		BaseDomain:        baseDomain,
 		ManagementCluster: managementCluster,
 	}).SetupWithManager(mgr); err != nil {

--- a/pkg/cloud/cache/cache.go
+++ b/pkg/cloud/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +15,11 @@ const (
 	zoneRecordsPrefix           = "zoneRecords"
 	zoneIDPrefix                = "zoneID"
 	nameserverRecordsPrefix     = "nameserverRecords"
+
+	ClusterIngressRecords = 1
+	ZoneRecords           = 2
+	ZoneID                = 3
+	NameserverRecords     = 4
 )
 
 // Setting an own cache config as the default configuration will lead in
@@ -60,50 +66,53 @@ func NewDNSOperatorCache() (*bigcache.BigCache, error) {
 	return bigcache.NewBigCache(config)
 }
 
-func GetDNSCacheZoneRecordsPrefixEntry(keySuffix string) ([]byte, error) {
-	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
+func GetDNSCacheRecord(recordID int, keySuffix string) ([]byte, error) {
+
+	switch recordID {
+	case ClusterIngressRecords:
+		return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
+	case ZoneRecords:
+		return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
+	case ZoneID:
+		return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
+	case NameserverRecords:
+		return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
+	default:
+		return nil, errors.New("no known cache identifier")
+	}
+
 }
 
-func SetDNSCacheZoneRecordsPrefixEntry(keySuffix string, data []byte) error {
-	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix), data)
+func SetDNSCacheRecord(recordID int, keySuffix string, data []byte) error {
+
+	switch recordID {
+	case ClusterIngressRecords:
+		return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix), data)
+	case ZoneRecords:
+		return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix), data)
+	case ZoneID:
+		return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix), data)
+	case NameserverRecords:
+		return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix), data)
+	default:
+		return errors.New("no known cache identifier")
+	}
+
 }
 
-func DeleteDNSCacheZoneRecordsPrefixEntry(keySuffix string) error {
-	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
-}
+func DeleteDNSCacheRecord(recordID int, keySuffix string) error {
 
-func GetDNSCacheZoneIDPrefixEntry(keySuffix string) ([]byte, error) {
-	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
-}
+	switch recordID {
+	case ClusterIngressRecords:
+		return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
+	case ZoneRecords:
+		return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
+	case ZoneID:
+		return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
+	case NameserverRecords:
+		return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
+	default:
+		return errors.New("no known cache identifier")
+	}
 
-func SetDNSCacheZoneIDPrefixEntry(keySuffix string, data []byte) error {
-	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix), data)
-}
-
-func DeleteDNSCacheZoneIDPrefixEntry(keySuffix string) error {
-	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
-}
-
-func GetDNSCacheNameserverRecordsEntry(keySuffix string) ([]byte, error) {
-	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
-}
-
-func SetDNSCacheNameserverRecordsEntry(keySuffix string, data []byte) error {
-	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix), data)
-}
-
-func DeleteDNSCacheNameserverRecordsEntry(keySuffix string) error {
-	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
-}
-
-func GetDNSCacheClusterIngressRecordsEntry(keySuffix string) ([]byte, error) {
-	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
-}
-
-func SetDNSCacheClusterIngressRecordsEntry(keySuffix string, data []byte) error {
-	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix), data)
-}
-
-func DeleteDNSCacheClusterIngressRecordsEntry(keySuffix string) error {
-	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
 }

--- a/pkg/cloud/cache/cache.go
+++ b/pkg/cloud/cache/cache.go
@@ -17,7 +17,7 @@ const (
 
 // Setting an own cache config as the default configuration will lead in
 // +80 MB in working_set_bytes
-var Config = bigcache.Config{
+var config = bigcache.Config{
 	// number of shards (must be a power of 2)
 	Shards: 256,
 
@@ -53,4 +53,9 @@ var Config = bigcache.Config{
 	// Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
 	// Ignored if OnRemove is specified.
 	OnRemoveWithReason: nil,
+}
+
+// NewDNSOperatorCache create a new BigCache with our custom configuration
+func NewDNSOperatorCache() (*bigcache.BigCache, error) {
+	return bigcache.NewBigCache(config)
 }

--- a/pkg/cloud/cache/cache.go
+++ b/pkg/cloud/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/allegro/bigcache/v3"
@@ -9,10 +10,10 @@ import (
 var DNSOperatorCache *bigcache.BigCache
 
 const (
-	ClusterIngressRecordsPrefix = "ingressRecords"
-	ZoneRecordsPrefix           = "zoneRecords"
-	ZoneIDPrefix                = "zoneID"
-	NameserverRecordsPrefix     = "nameserverRecords"
+	clusterIngressRecordsPrefix = "ingressRecords"
+	zoneRecordsPrefix           = "zoneRecords"
+	zoneIDPrefix                = "zoneID"
+	nameserverRecordsPrefix     = "nameserverRecords"
 )
 
 // Setting an own cache config as the default configuration will lead in
@@ -55,7 +56,54 @@ var config = bigcache.Config{
 	OnRemoveWithReason: nil,
 }
 
-// NewDNSOperatorCache create a new BigCache with our custom configuration
 func NewDNSOperatorCache() (*bigcache.BigCache, error) {
 	return bigcache.NewBigCache(config)
+}
+
+func GetDNSCacheZoneRecordsPrefixEntry(keySuffix string) ([]byte, error) {
+	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
+}
+
+func SetDNSCacheZoneRecordsPrefixEntry(keySuffix string, data []byte) error {
+	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix), data)
+}
+
+func DeleteDNSCacheZoneRecordsPrefixEntry(keySuffix string) error {
+	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneRecordsPrefix, keySuffix))
+}
+
+func GetDNSCacheZoneIDPrefixEntry(keySuffix string) ([]byte, error) {
+	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
+}
+
+func SetDNSCacheZoneIDPrefixEntry(keySuffix string, data []byte) error {
+	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix), data)
+}
+
+func DeleteDNSCacheZoneIDPrefixEntry(keySuffix string) error {
+	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", zoneIDPrefix, keySuffix))
+}
+
+func GetDNSCacheNameserverRecordsEntry(keySuffix string) ([]byte, error) {
+	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
+}
+
+func SetDNSCacheNameserverRecordsEntry(keySuffix string, data []byte) error {
+	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix), data)
+}
+
+func DeleteDNSCacheNameserverRecordsEntry(keySuffix string) error {
+	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", nameserverRecordsPrefix, keySuffix))
+}
+
+func GetDNSCacheClusterIngressRecordsEntry(keySuffix string) ([]byte, error) {
+	return DNSOperatorCache.Get(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
+}
+
+func SetDNSCacheClusterIngressRecordsEntry(keySuffix string, data []byte) error {
+	return DNSOperatorCache.Set(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix), data)
+}
+
+func DeleteDNSCacheClusterIngressRecordsEntry(keySuffix string) error {
+	return DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", clusterIngressRecordsPrefix, keySuffix))
 }

--- a/pkg/cloud/cache/cache.go
+++ b/pkg/cloud/cache/cache.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/allegro/bigcache/v3"
+)
+
+var DNSOperatorCache *bigcache.BigCache
+
+const (
+	ClusterIngressRecordsPrefix = "ingressRecords"
+	ZoneRecordsPrefix           = "zoneRecords"
+	ZoneIDPrefix                = "zoneID"
+	NameserverRecordsPrefix     = "nameserverRecords"
+)
+
+// Setting an own cache config as the default configuration will lead in
+// +80 MB in working_set_bytes
+var Config = bigcache.Config{
+	// number of shards (must be a power of 2)
+	Shards: 256,
+
+	// time after which entry can be evicted
+	LifeWindow: 6 * time.Minute,
+
+	// Interval between removing expired entries (clean up).
+	// If set to <= 0 then no action is performed.
+	// Setting to < 1 second is counterproductive — bigcache has a one second resolution.
+	CleanWindow: 5 * time.Minute,
+
+	// rps * lifeWindow, used only in initial memory allocation
+	MaxEntriesInWindow: 1000 * 10 * 60,
+
+	// max entry size in bytes, used only in initial memory allocation
+	MaxEntrySize: 500,
+
+	// prints information about additional memory allocation
+	Verbose: true,
+
+	// cache will not allocate more memory than this limit, value in MB
+	// if value is reached then the oldest entries can be overridden for the new ones
+	// 0 value means no size limit
+	HardMaxCacheSize: 24,
+
+	// callback fired when the oldest entry is removed because of its expiration time or no space left
+	// for the new entry, or because delete was called. A bitmask representing the reason will be returned.
+	// Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
+	OnRemove: nil,
+
+	// OnRemoveWithReason is a callback fired when the oldest entry is removed because of its expiration time or no space left
+	// for the new entry, or because delete was called. A constant representing the reason will be passed through.
+	// Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
+	// Ignored if OnRemove is specified.
+	OnRemoveWithReason: nil,
+}

--- a/pkg/cloud/services/route53/errors.go
+++ b/pkg/cloud/services/route53/errors.go
@@ -20,17 +20,21 @@ var notFoundError = &microerror.Error{
 	Kind: "notFoundError",
 }
 
-var hostedZoneNotFoundError = &microerror.Error{
-	Kind: "hostedZoneNotFoundError",
-}
-
 // IsHostedZoneNotFound asserts hostedZoneNotFoundError.
 func IsHostedZoneNotFound(err error) bool {
 	return microerror.Cause(err) == hostedZoneNotFoundError
 }
 
-var ingressNotReadyError = &microerror.Error{
-	Kind: "ingressNotReadyError",
+var hostedZoneNotFoundError = &microerror.Error{
+	Kind: "hostedZoneNotFoundError",
+}
+
+func IsThrottlingRateExceededError(err error) bool {
+	return microerror.Cause(err) == rateLimitHitError
+}
+
+var rateLimitHitError = &microerror.Error{
+	Kind: "throttlingRateExceededError",
 }
 
 // IsIngressNotRead asserts ingressNotReadyError.
@@ -38,13 +42,17 @@ func IsIngressNotReady(err error) bool {
 	return microerror.Cause(err) == ingressNotReadyError
 }
 
-var tooManyICServicesError = &microerror.Error{
-	Kind: "tooManyICServicesError",
+var ingressNotReadyError = &microerror.Error{
+	Kind: "ingressNotReadyError",
 }
 
 // IsTooManyICServices asserts tooManyICServicesError.
 func IsTooManyICServices(err error) bool {
 	return microerror.Cause(err) == tooManyICServicesError
+}
+
+var tooManyICServicesError = &microerror.Error{
+	Kind: "tooManyICServicesError",
 }
 
 func wrapRoute53Error(err error) error {
@@ -56,8 +64,12 @@ func wrapRoute53Error(err error) error {
 			if strings.Contains(err.Error(), "not found") {
 				return microerror.Mask(notFoundError)
 			}
+		case route53.ErrCodeThrottlingException:
+			return microerror.Mask(rateLimitHitError)
 		}
 	}
 
 	return microerror.Mask(err)
 }
+
+// check later - imo no need to wrap the errors

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -2,16 +2,21 @@ package route53
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/allegro/bigcache/v3"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dnscache "github.com/giantswarm/dns-operator-route53/pkg/cloud/cache"
 )
 
 const (
@@ -26,6 +31,7 @@ const (
 )
 
 func (s *Service) DeleteRoute53(ctx context.Context) error {
+
 	log := log.FromContext(ctx)
 	log.Info("Deleting hosted DNS zone")
 
@@ -61,27 +67,34 @@ func (s *Service) ReconcileRoute53(ctx context.Context) error {
 	log := log.FromContext(ctx)
 	log.Info("Reconciling hosted DNS zone")
 
-	// Describe or create.
-	hostedZoneID, err := s.describeClusterHostedZone(ctx)
-	if IsHostedZoneNotFound(err) {
-		hostedZoneID, err = s.createClusterHostedZone(ctx)
-		if err != nil {
+	cachedHostedZoneID, err := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.Name()))
+	if errors.Is(err, bigcache.ErrEntryNotFound) {
+		log.Info(fmt.Sprintf("no hostedZoneID found in local cache for cluster %s", s.scope.Name()))
+		// Describe or create.
+		hostedZoneID, err := s.describeClusterHostedZone(ctx)
+		if IsHostedZoneNotFound(err) {
+			hostedZoneID, err = s.createClusterHostedZone(ctx)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			log.Info(fmt.Sprintf("Created new hosted zone for cluster %s", s.scope.Name()))
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
-		log.Info(fmt.Sprintf("Created new hosted zone for cluster %s", s.scope.Name()))
-	} else if err != nil {
+
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.Name()), []byte(hostedZoneID))
+		cachedHostedZoneID, _ = dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.Name()))
+	}
+
+	if err := s.changeClusterNSDelegation(ctx, string(cachedHostedZoneID), actionUpsert); err != nil {
 		return microerror.Mask(err)
 	}
 
-	if err := s.changeClusterNSDelegation(ctx, hostedZoneID, actionUpsert); err != nil {
+	if err := s.changeClusterRecords(ctx, string(cachedHostedZoneID), actionUpsert); err != nil {
 		return microerror.Mask(err)
 	}
 
-	if err := s.changeClusterRecords(ctx, hostedZoneID, actionUpsert); err != nil {
-		return microerror.Mask(err)
-	}
-
-	if err := s.changeClusterIngressRecords(ctx, hostedZoneID, actionUpsert); err != nil {
+	if err := s.changeClusterIngressRecords(ctx, string(cachedHostedZoneID), actionUpsert); err != nil {
 		return microerror.Mask(err)
 	}
 
@@ -135,25 +148,61 @@ func (s *Service) changeClusterIngressRecords(ctx context.Context, hostedZoneID,
 		},
 	}
 
-	if _, err := s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input); err != nil {
-		return wrapRoute53Error(err)
+	cachedClusterIngressRecords, _ := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ClusterIngressRecordsPrefix, hostedZoneID))
+	if input.String() != string(cachedClusterIngressRecords) {
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.ClusterIngressRecordsPrefix, hostedZoneID), []byte(input.String()))
+
+		if _, err := s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input); err != nil {
+			return wrapRoute53Error(err)
+		}
 	}
+
 	return nil
 }
 
 func (s *Service) changeClusterNSDelegation(ctx context.Context, hostedZoneID, action string) error {
-	records, err := s.listClusterNSRecords(ctx, hostedZoneID)
-	if err != nil {
-		return microerror.Mask(err)
+	log := log.FromContext(ctx)
+
+	var resourceRecords []*route53.ResourceRecord
+	cachedRecords, err := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.NameserverRecordsPrefix, hostedZoneID))
+	if errors.Is(err, bigcache.ErrEntryNotFound) {
+		log.V(4).Info(fmt.Sprintf("no cached name server records found for zone %s", hostedZoneID))
+
+		resourceRecords, err = s.listClusterNSRecords(ctx, hostedZoneID)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		jsonRecords, _ := json.Marshal(resourceRecords)
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.NameserverRecordsPrefix, hostedZoneID), []byte(jsonRecords))
+		cachedRecords, _ = dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.NameserverRecordsPrefix, hostedZoneID))
 	}
 
-	baseHostedZoneID, err := s.describeBaseHostedZone(ctx)
-	if err != nil {
-		return microerror.Mask(err)
+	if err := json.Unmarshal(cachedRecords, &resourceRecords); err != nil {
+		return err
 	}
+
+	//log.V(6).WithValues("cluster", s.scope.ClusterDomain(), "records", resourceRecords)
+	log.V(6).WithValues("cluster", s.scope.ClusterDomain(), "records", resourceRecords)
+	log.WithValues("cluster logv6", s.scope.ClusterDomain(), "records", resourceRecords)
+
+	cachedBaseHostedZoneID, err := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.ClusterDomain()))
+	if errors.Is(err, bigcache.ErrEntryNotFound) {
+		log.Info(fmt.Sprintf("no cached zone id found for domain %s", s.scope.ClusterDomain()))
+
+		baseHostedZoneID, err := s.describeBaseHostedZone(ctx)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.ClusterDomain()), []byte(baseHostedZoneID))
+		cachedBaseHostedZoneID, _ = dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneIDPrefix, s.scope.ClusterDomain()))
+	}
+
+	log.V(6).WithValues("cluster", s.scope.ClusterDomain(), "zone ID", string(cachedBaseHostedZoneID))
 
 	input := &route53.ChangeResourceRecordSetsInput{
-		HostedZoneId: aws.String(baseHostedZoneID),
+		HostedZoneId: aws.String(string(cachedBaseHostedZoneID)),
 		ChangeBatch: &route53.ChangeBatch{
 			Changes: []*route53.Change{
 				{
@@ -162,17 +211,27 @@ func (s *Service) changeClusterNSDelegation(ctx context.Context, hostedZoneID, a
 						Name:            aws.String(s.scope.ClusterDomain()),
 						Type:            aws.String("NS"),
 						TTL:             aws.Int64(ttl),
-						ResourceRecords: records,
+						ResourceRecords: resourceRecords,
 					},
 				},
 			},
 		},
 	}
 
-	_, err = s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input)
-	if err != nil {
-		return wrapRoute53Error(err)
+	cachedBaseHostedZoneIDRecords, _ := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, s.scope.ClusterDomain()))
+
+	// if cached input differ from computed input
+	if input.String() != string(cachedBaseHostedZoneIDRecords) {
+		log.Info(fmt.Sprintf("cached records for zone ID %s differs from computed records. Updating ResourceRecordSet", string(cachedBaseHostedZoneID)))
+
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, s.scope.ClusterDomain()), []byte(input.String()))
+
+		_, err := s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input)
+		if err != nil {
+			return wrapRoute53Error(err)
+		}
 	}
+
 	return nil
 }
 
@@ -185,32 +244,55 @@ func (s *Service) changeClusterRecords(ctx context.Context, hostedZoneID string,
 		},
 	}
 
-	recordSets, err := s.listResourceRecordSets(ctx, hostedZoneID)
-	if err != nil {
-		return wrapRoute53Error(err)
+	cachedHostedZoneIDRecordSets, err := dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, hostedZoneID))
+	if errors.Is(err, bigcache.ErrEntryNotFound) {
+
+		log.Info(fmt.Sprintf("no cached resource record set found for zone id %s", hostedZoneID))
+
+		recordSets, err := s.listResourceRecordSets(ctx, hostedZoneID)
+		if err != nil {
+			return wrapRoute53Error(err)
+		}
+
+		jsonRecords, _ := json.Marshal(recordSets.ResourceRecordSets)
+		dnscache.DNSOperatorCache.Set(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, hostedZoneID), []byte(jsonRecords))
+		cachedHostedZoneIDRecordSets, _ = dnscache.DNSOperatorCache.Get(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, hostedZoneID))
 	}
 
+	var recordSets []*route53.ResourceRecordSet
+	if err := json.Unmarshal(cachedHostedZoneIDRecordSets, &recordSets); err != nil {
+		return err
+	}
+
+	// check if we already have entries for the supported "core" endpoints
+	// kubernetes API IP & bastion host IP
+	var endpointIPs struct {
+		kubernetesAPI bool
+		bastionIP     bool
+	}
+	for _, recordSet := range recordSets {
+		if *recordSet.Name == "api"+"."+s.scope.Name()+"."+s.scope.BaseDomain()+"." {
+			endpointIPs.kubernetesAPI = true
+		}
+		if *recordSet.Name == "bastion1"+"."+s.scope.Name()+"."+s.scope.BaseDomain()+"." {
+			endpointIPs.bastionIP = true
+		}
+	}
+
+	// decide if we need changes
 	if s.scope.APIEndpoint() == "" {
 		log.Info("API endpoint is not ready yet.")
 		return aws.ErrMissingEndpoint
-	}
-
-	log.Info("route53", "Kubernetes API endpoint", s.scope.APIEndpoint())
-
-	input.ChangeBatch.Changes = append(input.ChangeBatch.Changes,
-		s.buildARecordChange(hostedZoneID, "api", s.scope.APIEndpoint(), actionUpsert),
-	)
-
-	if s.scope.BastionIP() != "" {
-		log.Info("route53", "bastion IP", s.scope.BastionIP())
-
+	} else if s.scope.APIEndpoint() != "" && !endpointIPs.kubernetesAPI {
+		input.ChangeBatch.Changes = append(input.ChangeBatch.Changes,
+			s.buildARecordChange(hostedZoneID, "api", s.scope.APIEndpoint(), actionUpsert),
+		)
+	} else if s.scope.BastionIP() != "" && !endpointIPs.bastionIP {
 		input.ChangeBatch.Changes = append(input.ChangeBatch.Changes,
 			s.buildARecordChange(hostedZoneID, "bastion1", s.scope.BastionIP(), actionUpsert),
 		)
-	}
-
-	if s.scope.BastionIP() == "" {
-		for _, recordSet := range recordSets.ResourceRecordSets {
+	} else if s.scope.BastionIP() == "" {
+		for _, recordSet := range recordSets {
 			if *recordSet.Name == "bastion1"+"."+s.scope.Name()+"."+s.scope.BaseDomain()+"." {
 				log.Info("orphaned bastion record found", "name", *recordSet.Name, "record", *recordSet.ResourceRecords[0].Value)
 				input.ChangeBatch.Changes = append(input.ChangeBatch.Changes,
@@ -220,9 +302,15 @@ func (s *Service) changeClusterRecords(ctx context.Context, hostedZoneID string,
 		}
 	}
 
-	if _, err := s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input); err != nil {
-		return wrapRoute53Error(err)
+	if len(input.ChangeBatch.Changes) > 0 {
+		// invalidate the cache
+		dnscache.DNSOperatorCache.Delete(fmt.Sprintf("%s-%s", dnscache.ZoneRecordsPrefix, hostedZoneID))
+
+		if _, err := s.Route53Client.ChangeResourceRecordSetsWithContext(ctx, input); err != nil {
+			return wrapRoute53Error(err)
+		}
 	}
+
 	return nil
 }
 
@@ -300,13 +388,11 @@ func (s *Service) deleteClusterRecords(ctx context.Context, hostedZoneID string)
 }
 
 func (s *Service) describeBaseHostedZone(ctx context.Context) (string, error) {
-	log := log.FromContext(ctx)
 	input := &route53.ListHostedZonesByNameInput{
 		DNSName: aws.String(s.scope.BaseDomain()),
 	}
 	out, err := s.Route53Client.ListHostedZonesByNameWithContext(ctx, input)
 	if err != nil {
-		log.Info(err.Error())
 		return "", wrapRoute53Error(err)
 	}
 	if len(out.HostedZones) == 0 {


### PR DESCRIPTION
as we got rate-limited by aws-route53, this change introduces an internal cache. API-Responses for all GET requests will be cached.

During each reconciliation we calculate the desired state and compare this state with the cached state.

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
