### PR TITLE
Support new ingress-nginx app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Respect new `ingress-nginx` app in addition to existing `nginx-ingress-controller` app.
+
 ## [0.7.3] - 2023-03-31
 
 ### Fixed

--- a/pkg/cloud/services/route53/route53.go
+++ b/pkg/cloud/services/route53/route53.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -21,11 +22,10 @@ import (
 )
 
 const (
-	appNameLabelKey = "app.kubernetes.io/name"
+	ingressServiceSelector = "app.kubernetes.io/name in (ingress-nginx,nginx-ingress-controller)"
+	ingressAppNamespace    = "kube-system"
 
-	ingressAppLabel     = "nginx-ingress-controller"
-	ingressAppNamespace = "kube-system"
-	ttl                 = 300
+	ttl = 300
 
 	actionDelete = "DELETE"
 	actionUpsert = "UPSERT"
@@ -484,7 +484,7 @@ func (s *Service) getIngressIP(ctx context.Context) (string, error) {
 
 	err = k8sClient.List(ctx, &icServices,
 		client.InNamespace(ingressAppNamespace),
-		client.MatchingLabels{appNameLabelKey: ingressAppLabel},
+		&client.ListOptions{Raw: &metav1.ListOptions{LabelSelector: ingressServiceSelector}},
 	)
 
 	if err != nil {


### PR DESCRIPTION
The name of nginx ingress app is changed. This PR adapts the operator so that it respects old&new app at the same time by using `app.kubernetes.io/name` label. 

***How I did test this PR***
- I deployed this version to my test MC.
- I created a WC.
- I deployed the old nginx-ingress-controller-app (2.30.1) and observed expected DNS records on route53.
- I removed the old app. I removed all DNS records and hosted zone on route53.
- I deployed the new ingress-nginx (3.0.0-beta1) and  observed expected DNS records on route53.

***Note***

We don't need to wait for anything to release this change. It is backward compatible. After this change, feel free to migrate nginx ingress apps in MCs and WCs. 

### Checklist

- [x] Update changelog in CHANGELOG.md.
