### PR TITLE
ignore CVE-2023-3978

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -11,4 +11,4 @@ CVE-2023-32731 until=2023-09-01
 CVE-2020-8561 until=2023-09-01
 
 # pkg:golang/golang.org/x/net@v0.7.0
-CVE-2023-3978 until=2023-09-01
+CVE-2023-3978 until=2023-12-01

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -9,3 +9,6 @@ CVE-2023-32731 until=2023-09-01
 
 # pkg:golang/k8s.io/apiserver@v0.23.0
 CVE-2020-8561 until=2023-09-01
+
+# pkg:golang/golang.org/x/net@v0.7.0
+CVE-2023-3978 until=2023-09-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore CVE-2023-3978.
+
 ## [0.8.0] - 2023-07-18
 
 ### Added


### PR DESCRIPTION
This PR:

- configures nancy to ignore [CVE-2023-3978](https://ossindex.sonatype.org/vulnerability/CVE-2023-3978?component-type=golang&component-name=golang.org%2Fx%2Fnet&utm_source=nancy-client&utm_medium=integration&utm_content=1.0.37) as it does not affect us.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
