### PR TITLE
Increase default memory to 120Mi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ignore CVE-2023-3978.
 - Fix security issues reported by kyverno policies.
+- Make resource configuration configurable and increase default memory usage to 120Mi.
+
 
 ## [0.8.0] - 2023-07-18
 

--- a/helm/dns-operator-route53/templates/deployment.yaml
+++ b/helm/dns-operator-route53/templates/deployment.yaml
@@ -51,10 +51,9 @@ spec:
             {{- . | toYaml | nindent 10 }}
           {{- end }}
         resources:
-          requests:
-            memory: 100Mi
-          limits:
-            memory: 100Mi
+          {{- with .Values.pod.resources }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         volumeMounts:
         - mountPath: /home/.aws
           name: credentials

--- a/helm/dns-operator-route53/values.yaml
+++ b/helm/dns-operator-route53/values.yaml
@@ -16,6 +16,11 @@ pod:
     id: 1000
   group:
     id: 1000
+  resources:
+    limits:
+      memory: 120Mi
+    requests:
+      memory: 120Mi
 
 # necessary for RBACs
 # provider:


### PR DESCRIPTION
I observe OOMKilled in some clusters and memory
usage is around 90Mb in working clusters.
It is better to increase the buffer a little bit more.


### Checklist

- [x] Update changelog in CHANGELOG.md.
