### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,83 +1,64 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.34.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   build:
     jobs:
-    - architect/go-build:
-        context: architect
-        name: go-build
-        binary: dns-operator-route53
-        resource_class: xlarge
-        filters:
-          tags:
-            only: /^v.*/
-
-    - architect/push-to-docker:
-        context: architect
-        name: push-dns-operator-route53-to-quay
-        image: "quay.io/giantswarm/dns-operator-route53"
-        username_envar: "QUAY_USERNAME"
-        password_envar: "QUAY_PASSWORD"
-        requires:
-        - go-build
-        filters:
-          # Trigger the job also on git tag.
-          tags:
-            only: /^v.*/
-    - architect/push-to-docker:
-          context: "architect"
-          name: push-dns-operator-route53-to-docker
-          image: "docker.io/giantswarm/dns-operator-route53"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
+      - architect/go-build:
+          context: architect
+          name: go-build
+          binary: dns-operator-route53
+          resource_class: xlarge
           filters:
             tags:
               only: /^v.*/
 
-    # Ensure that for every commit
-    # there is an app version in the test catalog.
-    - architect/push-to-app-catalog:
-        context: architect
-        name: push-to-app-catalog
-        app_catalog: "control-plane-catalog"
-        app_catalog_test: "control-plane-test-catalog"
-        chart: "dns-operator-route53"
-        requires:
-        - push-dns-operator-route53-to-quay
-        - push-dns-operator-route53-to-docker
-        filters:
+      - architect/push-to-registries:
+          context: architect
+          name: push-to-registries
+          requires:
+            - go-build
+          filters:
           # Trigger the job also on git tag.
-          tags:
-            only: /^v.*/
+            tags:
+              only: /^v.*/
+      - architect/push-to-app-catalog:
+          context: architect
+          name: push-to-app-catalog
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "dns-operator-route53"
+          requires:
+            - push-to-registries
+          filters:
+          # Trigger the job also on git tag.
+            tags:
+              only: /^v.*/
 
-    - architect/push-to-app-collection:
-        context: architect
-        name: push-to-cloud-director-app-collection
-        app_name: "dns-operator-route53"
-        app_collection_repo: "cloud-director-app-collection"
-        requires:
-        - push-to-app-catalog
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-cloud-director-app-collection
+          app_name: "dns-operator-route53"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - push-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
-    - architect/push-to-app-collection:
-        context: architect
-        name: push-to-vsphere-app-collection
-        app_name: "dns-operator-route53"
-        app_collection_repo: "vsphere-app-collection"
-        requires:
-        - push-to-app-catalog
-        filters:
-          branches:
-            ignore: /.*/
-          tags:
-            only: /^v.*/
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-vsphere-app-collection
+          app_name: "dns-operator-route53"
+          app_collection_repo: "vsphere-app-collection"
+          requires:
+            - push-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

Context: [announcement in `#news-dev` on Slack](https://gigantic.slack.com/archives/C04TGHDEF/p1701170353580999)

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- [ ] Assign this PR to yourself
- [ ] Verify that the check `ci/circleci: push-to-registries` has been executed successfully.
- [ ] Double-check the job dependecies (`requires`)
- [ ] Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- [ ] Update the changelog if you think this deserves a mention
- [ ] Approve and merge this PR once it's ready. No need to wait for the author in this case.

Please get this done until **December 5**, so that we can move on with the next migration steps. Thank you!