### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Chnaged
-- Align PSS (deploy PSPs conditionally).
 ### Changed
 
+- Align PSS (deploy PSPs conditionally).
 - Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.8.1] - 2023-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Chnaged
-
 - Align PSS (deploy PSPs conditionally).
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.8.1] - 2023-08-24
 
@@ -18,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore CVE-2023-3978.
 - Fix security issues reported by kyverno policies.
 - Make resource configuration configurable and increase default memory usage to 120Mi.
-
 
 ## [0.8.0] - 2023-07-18
 

--- a/helm/dns-operator-route53/values.yaml
+++ b/helm/dns-operator-route53/values.yaml
@@ -9,7 +9,7 @@ image:
   name: "giantswarm/dns-operator-route53"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 pod:
   user:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
