### PR TITLE
Add missing team label

### DIFF
--- a/helm/dns-operator-route53/templates/_helpers.tpl
+++ b/helm/dns-operator-route53/templates/_helpers.tpl
@@ -21,6 +21,7 @@ app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}


### PR DESCRIPTION
This PR:

- adds the missing team label so the podmonitor is picked up by the correct prometheus

### Checklist

- [x] Update changelog in CHANGELOG.md.
