### PR TITLE
Do not reconcile aws infrastructure clusters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,16 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-vsphere-aws-addons-app-collection
+          app_name: "dns-operator-route53"
+          app_collection_repo: "vsphere-aws-addons-app-collection"
+          requires:
+            - push-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not reconcile Cluster if the infrastructure cluster kind is AWSCluster.
+
 ## [0.9.0] - 2024-07-25
 
 ### Changed

--- a/controllers/cluster_controller.go
+++ b/controllers/cluster_controller.go
@@ -64,6 +64,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// get the InfrastructureRef (v1.ObjectReference) from the CAPI cluster
 	infraRef := cluster.Spec.InfrastructureRef
 
+	// Return early if the infrastructure cluster type is not enabled
+	if !r.enabledInfrastructureProvider(infraRef.Kind) {
+		log.Info(fmt.Sprintf("Infrastructure provider %s is not enabled", infraRef.Kind))
+		return reconcile.Result{}, nil
+	}
+
 	// set the GVK to the unstructured infraCluster
 	infraCluster.SetGroupVersionKind(infraRef.GroupVersionKind())
 
@@ -187,4 +193,16 @@ func (r *ClusterReconciler) reconcileDelete(ctx context.Context, clusterScope *s
 		Requeue:      true,
 		RequeueAfter: time.Minute * 5,
 	}, nil
+}
+
+// check if the infrastructure provider is enabled
+// for now we simply disable the AWS provider here.
+// if needed in the future we should extend this to accept a list of enabled providers from the config.
+func (r *ClusterReconciler) enabledInfrastructureProvider(kind string) bool {
+	switch kind {
+	case "AWSCluster":
+		return false
+	default:
+		return true
+	}
 }


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3624

This PR:

- disables reconciling AWSCluster type infra clusters. This is needed in order to support CAPV on CAPA hybrid environments and correctly handle CAPV dns while leaving CAPA alone.
- in the future we can add flags that would allow us to enable or disable certain infrastructure types on MC basis if needed
- we also push this to the capa-capv app collection now
<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
