### PR TITLE
Add support for Proxmox clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Proxmox clusters.
+
 ### Changed
 
 - The `network.giantswarm.io/wildcard-cname-target` annotation value is now used as a prefix and suffixed with the cluster domain, instead of being used as the full CNAME target.

--- a/helm/dns-operator-route53/templates/_helpers.tpl
+++ b/helm/dns-operator-route53/templates/_helpers.tpl
@@ -56,5 +56,7 @@ vcdclusters
 vsphereclusters
 {{- else if eq .Values.provider.kind "capa" -}}
 vsphereclusters
+{{- else if eq .Values.provider.kind "proxmox" -}}
+proxmoxclusters
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/36364

This PR:

- Adds proxmox support.

### Verification

Operator logs:

```
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	Reconciling cluster normal	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	cluster.x-k8s.io/v1beta1 Cluster is deprecated; use cluster.x-k8s.io/v1beta2 Cluster	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	metadata.finalizers: "dns-operator-route53.finalizers.giantswarm.io": prefer a domain-qualified finalizer name including a path (/) to avoid accidental conflicts with other finalizer writers	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	metadata.finalizers: "dns-operator-route53.finalizers.giantswarm.io": prefer a domain-qualified finalizer name including a path (/) to avoid accidental conflicts with other finalizer writers	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	Reconciling hosted DNS zone	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:48Z	INFO	no hostedZoneID found in local cache for cluster wealdy	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	no cached zone id found for domain wealdy.test.gigantic.io	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	cached records for zone ID /hostedzone/Z08921901APWT6JBKDYU4 differs from computed records. Updating ResourceRecordSet	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	no cached resource record set found for zone id /hostedzone/Z079758527IQPUS66L6L2	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "490a5f22-7e7b-4eb2-8157-c7c2d79ce22a"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	Reconciling cluster normal	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "a34de09f-5b40-40af-b3f9-00b3bc6dc3a7"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	Reconciling hosted DNS zone	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "a34de09f-5b40-40af-b3f9-00b3bc6dc3a7"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:36:49Z	INFO	no cached resource record set found for zone id /hostedzone/Z079758527IQPUS66L6L2	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "a34de09f-5b40-40af-b3f9-00b3bc6dc3a7"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:37:50Z	INFO	Reconciling cluster normal	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "aab37629-ed7b-48b1-8343-997465f18416"}
proxmox-dns-operator-route53-84895654b8-gd2ns dns-operator-route53 2026-04-20T09:37:50Z	INFO	Reconciling hosted DNS zone	{"controller": "cluster", "controllerGroup": "cluster.x-k8s.io", "controllerKind": "Cluster", "Cluster": {"name":"wealdy","namespace":"org-wealdy"}, "namespace": "org-wealdy", "name": "wealdy", "reconcileID": "aab37629-ed7b-48b1-8343-997465f18416"}
```

And the created records match up:

```
➜  ykg proxmoxcluster wealdy | yq .spec.controlPlaneEndpoint.host
10.201.25.141
➜  dig +short api.wealdy.test.gigantic.io @1.1.1.1
10.201.25.141
```

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
