### PR TITLE
build: Remove build steps from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update module k8s.io/component-base to v0.36.1.
 - Update module sigs.k8s.io/controller-runtime to v0.24.1.
 - Update module sigs.k8s.io/cluster-api to v1.13.2.
+- Remove superfluous build steps from the Dockerfile.
 
 ## [0.13.0] - 2026-04-20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,12 @@
-# Build the manager binary
-FROM golang:1.26.3 as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-#COPY api/ api/
-COPY controllers/ controllers/
-COPY pkg/ pkg/
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
-
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+
+ARG TARGETOS
+ARG TARGETARCH
+COPY dns-operator-route53-${TARGETOS}-${TARGETARCH} /dns-operator-route53
+
 USER nonroot:nonroot
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/dns-operator-route53"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - command:
-        - /manager
+        - /dns-operator-route53
         args:
         - --enable-leader-election
         image: controller:latest

--- a/helm/dns-operator-route53/templates/deployment.yaml
+++ b/helm/dns-operator-route53/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /home/.aws/credentials
         command:
-        - /manager
+        - /dns-operator-route53
         args:
         - --enable-leader-election
         - --base-domain={{ .Values.baseDomain }}


### PR DESCRIPTION
This PR:

- Removes the build steps from the Dockerfile as these are already executed in the `go-build` step in the CircleCI workflow.

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.
